### PR TITLE
Auto config added for CI/CD

### DIFF
--- a/bin/config_build.py
+++ b/bin/config_build.py
@@ -75,7 +75,7 @@ def pull_new(files):
 	for file in files:
 		if any(regex.match(file) for regex in regexes):
 			print(f'Updating {file}...')
-			subprocess.run([f'{SDT_BASE}/bin/package_build.py', file])
+			subprocess.run([f'{SDT_BASE}/bin/package_build.py', file], stdout=subprocess.DEVNULL)
 
 if __name__ == "__main__":
 	print("Scanning distro_data directory...")

--- a/bin/config_build.py
+++ b/bin/config_build.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 import re
 import os
-import sys
 
 SDT_BASE = '/opt/software-discovery-tool'
 DATA_FILE_LOCATION = '%s/distro_data/distro_data' % SDT_BASE

--- a/bin/config_build.py
+++ b/bin/config_build.py
@@ -31,17 +31,15 @@ def addfile(file, ind):
 		data = DATA.read()
 	groups = regexes[ind].search(file)
 	if not ind == 0:
-		if groups.group(1) in data:
-			if not file in data:
-				start = data.index(groups.group(1)) + len(groups.group(1))+7
-				new_data = f"\t'{groups.group(1)} {groups.group(2)}.{groups.group(3)}': '{file}',\n"
-				flag = True
+		if groups.group(1) in data and not file in data:
+			start = data.index(groups.group(1)) + len(groups.group(1))+7
+			new_data = f"\t'{groups.group(1)} {groups.group(2)}.{groups.group(3)}': '{file}',\n"
+			flag = True
 	else:
-		if groups.group(1).replace('_', ' ') in data:
-			if not file in data:
-				start = data.index(groups.group(1).replace('_', ' ')) + len(groups.group(1))+7
-				new_data = f"\t'SLES {groups.group(4)} {'' if groups.group(6)==None else groups.group(6)}': '{file}',\n"
-				flag = True
+		if groups.group(1).replace('_', ' ') in data and not file in data:
+			start = data.index(groups.group(1).replace('_', ' ')) + len(groups.group(1))+7
+			new_data = f"\t'SLES {groups.group(4)} {'' if groups.group(6)==None else groups.group(6)}': '{file}',\n"
+			flag = True
 
 	if flag:
 		with open(SUPPORTED_DISTRO_FILE, 'r+') as DATA:

--- a/bin/config_build.py
+++ b/bin/config_build.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python3
+import re
+import os
+import sys
+
+SDT_BASE = '/opt/software-discovery-tool'
+DATA_FILE_LOCATION = '%s/distro_data/distro_data' % SDT_BASE
+SUPPORTED_DISTRO_FILE = '%s/src/config/supported_distros.py' % SDT_BASE
+
+SLES_reg = r'((x?Suse_Linux_Enterprise_Server)|(x?SUSE_Package_Hub)_SLES)_(\d{2})(_(SP\d))?_?.*\.json'
+RHEL_reg = r'(x?RHEL)_(\d{1,2})_(\d{1,2}).*\.json'
+Ubuntu_reg = r'(x?Ubuntu)_(\d{1,2})_(\d{1,2}).*\.json'
+regexes = [
+	re.compile(SLES_reg),
+	re.compile(RHEL_reg),
+	re.compile(Ubuntu_reg)
+]
+
+def scan():
+	return os.listdir(DATA_FILE_LOCATION)
+
+def packagetype(file):
+	global SLES_reg, RHEL_reg, Ubuntu_reg, regexes
+	for ind,reg in enumerate(regexes):
+		if reg.match(file):
+			addfile(file, ind)
+
+def addfile(file, ind):
+	global SLES_reg, RHEL_reg, Ubuntu_reg, regexes
+	flag = False
+	with open(SUPPORTED_DISTRO_FILE) as DATA:
+		data = DATA.read()
+	groups = regexes[ind].search(file)
+	if not ind == 0:
+		if groups.group(1) in data:
+			if not file in data:
+				start = data.index(groups.group(1)) + len(groups.group(1))+7
+				new_data = f"\t'{groups.group(1)} {groups.group(2)}.{groups.group(3)}': '{file}',\n"
+				flag = True
+	else:
+		if groups.group(1).replace('_', ' ') in data:
+			if not file in data:
+				start = data.index(groups.group(1).replace('_', ' ')) + len(groups.group(1))+7
+				new_data = f"\t'SLES {groups.group(4)} {'' if groups.group(6)==None else groups.group(6)}': '{file}',\n"
+				flag = True
+
+	if flag:
+		with open(SUPPORTED_DISTRO_FILE, 'r+') as DATA:
+			DATA.seek(start)
+			next_data = DATA.read()
+			print(f"Found new file: {file}")
+			DATA.seek(start)
+			DATA.write(new_data)
+			DATA.write(next_data)
+
+def format_data():
+	duplicate = []
+	with open(SUPPORTED_DISTRO_FILE, 'r+') as DATA:
+		old_format = DATA.read()
+		DATA.truncate(0)
+		new_format = re.sub(r"(json',\n})", "json'\n}", old_format)
+		DATA.seek(0)
+		DATA.write(new_format)
+
+def del_cache():
+	try:
+		print("Attempting to delete cached_data.json...")
+		os.remove(f'{DATA_FILE_LOCATION}/cached_data.json')
+	except:
+		print("File not found in directory.")
+
+if __name__ == "__main__":
+	print("Scanning distro_data directory...")
+	files = scan()
+	for file in files:
+		packagetype(file)
+	format_data()
+	del_cache()
+	print('Done.')

--- a/bin/config_build.py
+++ b/bin/config_build.py
@@ -23,7 +23,6 @@ def packagetype(file):
 	global SLES_reg, RHEL_reg, Ubuntu_reg, regexes
 	for ind,reg in enumerate(regexes):
 		if reg.match(file):
-			print(f"Found file: {file}")
 			addfile(file, ind)
 
 def addfile(file, ind):
@@ -35,11 +34,13 @@ def addfile(file, ind):
 	name = re.sub(r'^x', '', groups.group(1).replace('_', ' '))
 	if not ind == 0:
 		if name in data and not file in data:
+			print(f"Found new file: {file}")
 			start = data.index(name) + len(name)+7
 			new_data = f"\t'{groups.group(1)} {groups.group(2)}.{groups.group(3)}': '{file}',\n"
 			flag = True
 	else:
 		if name in data and not file in data:
+			print(f"Found new file: {file}")
 			start = data.index(name) + len(name)+7
 			new_data = f"\t'SLES {groups.group(4)} {'' if groups.group(6)==None else groups.group(6)}': '{file}',\n"
 			flag = True

--- a/docs/Adding_new_distros.md
+++ b/docs/Adding_new_distros.md
@@ -58,11 +58,19 @@ The Content of the distribution data JSON file has to be in the following format
 }]
 ```
 
-### Step 2. Update the SUPPORTED_DISTROS variable in configuration file `/<SDT_BASE>/src/config/config.py`
-Software Discovery application requires a mapping between each JSON file and relevant Distro Version.  This is done using SUPPORTED_DISTROS object in config file.
+### Step 2. Update the SUPPORTED_DISTROS variable in configuration file `/<SDT_BASE>/src/config/supported_ditros.py`
+Software Discovery application requires a mapping between each JSON file and relevant Distro Version.  This is done using SUPPORTED_DISTROS object in supported_distros file.
 SUPPORTED_DISTROS is a dictionary object having the "Distro Name" as the keys.  And each distro name has another dictionary having "Distro Version" has its key and "JSON file as its value"
 
-Software Discovery Tool uses the "Distro Name" and "Distro Version" keys to create "Display Names" of check-boxes on the Software Discovery Tool main page.  Ensure that there are no duplicate
+Software Discovery Tool uses an automatic script `config_build.py` to scan the directory and update the SUPPORTED_DISTROS object accordingly. It is highly crucial to follow the naming file scheme,
+which is `<DistroName>_<DistroVersion>.json`. This is helpful for the script to parse through the file name and update the object with the correct distro version and name.
+To use the script, just follow:
+```
+sudo -u apache ./bin/config_build.py
+```
+With this, it also tries to update all data files taken from PDS to keep them working as the latest versions.
+
+Software Discovery Tool also uses the "Distro Name" and "Distro Version" keys to create "Display Names" of check-boxes on the Software Discovery Tool main page.  Ensure that there are no duplicate
 "Distro Name" or "Distro Version" entries.
 
 SUPPORTED_DISTROS must have following structure
@@ -116,11 +124,19 @@ Software Discovery Tool may assign following flags to the distros...
 ```
 In case the `PackageNameX` is available in in `Ubuntu 20.04` and `Ubuntu 20.10` then the `B` will be set to `6`
 
-Cache file has to be regenerated whenever there is a change in SUPPORTED_DISTROS object.  Hence delete the existing cache as follows:
-
+Cache file has to be regenerated whenever there is a change in `supported_distros.py` file. Fortunately, `bin/config_build.py` does that for you. With this, it also attempts to update PDS data sources, if found any, to the latest version as available on their repository.
 ```
-cd <DATA_FILE_LOCATION>
-rm -f cached_data.json
+sudo -u apache ./bin/config_build.py
+Scanning distro_data directory...
+Found file: xUbuntu_21_04_Package_List.json
+Attempting to update PDS data sources...
+Updating xUbuntu_21_04_Package_List.json...
+Extracting xUbuntu_21_04_Package_List.json from PDS data ...
+Saved!
+filename: xUbuntu_21_04_Package_List.json
+Thanks for using SDT!
+Attempting to delete cached_data.json...
+File not found in directory.
+Done.
 ```
-
 ### Step 4. Restart the server by referring to the steps mentioned in [Installation](Installation.md) document.

--- a/docs/Adding_new_distros.md
+++ b/docs/Adding_new_distros.md
@@ -58,7 +58,7 @@ The Content of the distribution data JSON file has to be in the following format
 }]
 ```
 
-### Step 2. Update the SUPPORTED_DISTROS variable in configuration file `/<SDT_BASE>/src/config/supported_ditros.py`
+### Step 2. Update the SUPPORTED_DISTROS variable in file `/<SDT_BASE>/src/config/supported_ditros.py`
 Software Discovery application requires a mapping between each JSON file and relevant Distro Version.  This is done using SUPPORTED_DISTROS object in supported_distros file.
 SUPPORTED_DISTROS is a dictionary object having the "Distro Name" as the keys.  And each distro name has another dictionary having "Distro Version" has its key and "JSON file as its value"
 
@@ -124,7 +124,7 @@ Software Discovery Tool may assign following flags to the distros...
 ```
 In case the `PackageNameX` is available in in `Ubuntu 20.04` and `Ubuntu 20.10` then the `B` will be set to `6`
 
-Cache file has to be regenerated whenever there is a change in `supported_distros.py` file. Fortunately, `bin/config_build.py` does that for you. With this, it also attempts to update PDS data sources, if found any, to the latest version as available on their repository.
+Cache file has to be regenerated whenever there is a change in `supported_distros.py` file. Fortunately, `bin/config_build.py` does that for you. Incase, it does not find any cached_data.json file, it says so. With this, it also attempts to update all the PDS data sources, if found any in the directory, to the latest version as available on their repository.
 ```
 sudo -u apache ./bin/config_build.py
 Scanning distro_data directory...

--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -144,7 +144,7 @@ Thanks for using SDT!
 	```
 	sudo -u apache ./bin/package_build.py RHEL_8_Package_List.json
 	```
-Now to know how to update the `src/config/config.py` to reflect the new json files in the UI, follow steps mentioned in
+Now to know how to update the `src/config/supported_distros.py` to reflect the new json files in the UI, follow steps mentioned in
 Step 2 of
 [Adding_new_distros](https://github.com/openmainframeproject/software-discovery-tool/blob/master/docs/Adding_new_distros.md#step-2-update-the-supported_distros-variable-in-configuration-file-sdt_basesrcconfigconfigpy)
 

--- a/src/classes/package_search.py
+++ b/src/classes/package_search.py
@@ -5,7 +5,7 @@ import collections
 import copy 
 import math
 from config import DATA_FILE_LOCATION, DISABLE_PAGINATION, MAX_RECORDS_TO_CONCAT, LOGGER, MAX_RECORDS_TO_SEND, CACHE_SIZE
-from config import SUPPORTED_DISTROS
+from config.supported_distros import SUPPORTED_DISTROS
 
 class PackageSearch:
     package_data = {}

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -1,5 +1,6 @@
 import urllib.request, urllib.error, urllib.parse
 import logging
+from config import supported_distros
 
 SDT_BASE = '/opt/software-discovery-tool'
 DATA_FILE_LOCATION = '%s/distro_data/distro_data' % SDT_BASE
@@ -32,22 +33,6 @@ NOTSET
 Refer https://docs.python.org/2/library/logging.html for more information.
 '''
 DEBUG_LEVEL = logging.ERROR
-
-SUPPORTED_DISTROS = {
-	'IBM z/OS ™': {
-		'z/OS Software': 'ZOS_Software_List.json'
-	},
-	'Debian 10': {
-		'Buster': 'Debian_Buster_List.json'
-	},
-	'ClefOS': {
-		'ClefOS Base 7': 'ClefOS_7_List.json'
-	},
-	'OpenSUSE': {
-		'Leap 15.3': 'OpenSUSE_Leap_15_3.json',
-		'Tumbleweed': 'OpenSUSE_Tumbleweed.json'
-	}
-}
 
 logging.basicConfig(format='%(asctime)s %(message)s', filename=LOG_FILE_LOCATION, level=DEBUG_LEVEL)
 

--- a/src/config/supported_distros.py
+++ b/src/config/supported_distros.py
@@ -1,0 +1,30 @@
+SUPPORTED_DISTROS = {
+'IBM z/OS ™': {
+	'z/OS Software': 'ZOS_Software_List.json'
+},
+'Debian 10': {
+	'Buster': 'Debian_Buster_List.json'
+},
+'ClefOS': {
+	'ClefOS Base 7': 'ClefOS_7_List.json'
+},
+'OpenSUSE': {
+	'Leap 15.3': 'OpenSUSE_Leap_15_3.json',
+	'Tumbleweed': 'OpenSUSE_Tumbleweed.json'
+},
+'SUSE Package Hub SLES': {
+	'SLES 15 ': 'SUSE_Package_Hub_SLES_15.json',
+	'SLES 12 SP5': 'SUSE_Package_Hub_SLES_12_SP5.json'
+},
+'Suse Linux Enterprise Server': {
+	'SLES 15 ': 'Suse_Linux_Enterprise_Server_15_Package_List.json',
+	'SLES 15 SP2': 'Suse_Linux_Enterprise_Server_15_SP2_Package_List.json'
+},
+'Ubuntu': {
+	'Ubuntu 20.10': 'Ubuntu_20_10_Package_List.json',
+	'Ubuntu 18.04': 'Ubuntu_18_04_Package_List.json'
+},
+'RHEL': {
+	'RHEL 8.4': 'RHEL_8_4_Package_List.json'
+}
+}

--- a/src/config/supported_distros.py
+++ b/src/config/supported_distros.py
@@ -13,18 +13,11 @@ SUPPORTED_DISTROS = {
 	'Tumbleweed': 'OpenSUSE_Tumbleweed.json'
 },
 'SUSE Package Hub SLES': {
-	'SLES 15 ': 'SUSE_Package_Hub_SLES_15.json',
-	'SLES 12 SP5': 'SUSE_Package_Hub_SLES_12_SP5.json'
 },
 'Suse Linux Enterprise Server': {
-	'SLES 15 ': 'Suse_Linux_Enterprise_Server_15_Package_List.json',
-	'SLES 15 SP2': 'Suse_Linux_Enterprise_Server_15_SP2_Package_List.json'
 },
 'Ubuntu': {
-	'Ubuntu 20.10': 'Ubuntu_20_10_Package_List.json',
-	'Ubuntu 18.04': 'Ubuntu_18_04_Package_List.json'
 },
 'RHEL': {
-	'RHEL 8.4': 'RHEL_8_4_Package_List.json'
 }
 }


### PR DESCRIPTION
# fixes #47 

Signed-off-by: rachejazz <divyadeepti2000@gmail.com>

This step was taken originally to save the hassle of mapping json file manually, when wished to take data from PDS. Rest of the data provided by OMP will be added by us. Users, stay at peace :)
Following steps on how to use the new script:
### 1. Using `package_build.py` to extract data from PDS:
For example, `RHEL_8_1_Package_List.json`, `Suse_Linux_Enterprise_Server_12_SP5_Package_List.json`, `SUSE_Package_Hub_SLES_12_SP5.json` and `Ubuntu_16_04_Package_List.json` will be taken for demo.
```
divya@discoveryubuntu:/opt/software-discovery-tool$ sudo -u apache ./bin/package_build.py Ubuntu_16_04_Package_List.json
Extracting Ubuntu_16_04_Package_List.json from PDS data ... 
Saved!
filename: Ubuntu_16_04_Package_List.json
Thanks for using SDT!
```
```
divya@discoveryubuntu:/opt/software-discovery-tool$ sudo -u apache ./bin/package_build.py Suse_Linux_Enterprise_Server_12_SP5_Package_List.json
Extracting Suse_Linux_Enterprise_Server_12_SP5_Package_List.json from PDS data ... 
Saved!
filename: Suse_Linux_Enterprise_Server_12_SP5_Package_List.json
Thanks for using SDT!
```
```
divya@discoveryubuntu:/opt/software-discovery-tool$ sudo -u apache ./bin/package_build.py SUSE_Package_Hub_SLES_12_SP5.json
Extracting SUSE_Package_Hub_SLES_12_SP5.json from PDS data ... 
Saved!
filename: SUSE_Package_Hub_SLES_12_SP5.json
Thanks for using SDT!
```
```
divya@discoveryubuntu:/opt/software-discovery-tool$ sudo -u apache ./bin/package_build.py RHEL_8_1_Package_List.json
Extracting RHEL_8_1_Package_List.json from PDS data ... 
Saved!
filename: RHEL_8_1_Package_List.json
Thanks for using SDT!
```
### 2. Check the files are present in data directory
```
divya@discoveryubuntu:/opt/software-discovery-tool$ ls distro_data/distro_data/
cached_data.json          RHEL_8_1_Package_List.json
ClefOS_7_List.json        Suse_Linux_Enterprise_Server_12_SP5_Package_List.json
Debian_Buster_List.json   SUSE_Package_Hub_SLES_12_SP5.json
OpenSUSE_Leap_15_3.json   Ubuntu_16_04_Package_List.json
OpenSUSE_Tumbleweed.json  ZOS_Software_List.json
```
### 3. Using `config_build.py` to automate config update
*NOTE* The script deletes any cache data that was present before. So no need of manual removal.
```
divya@discoveryubuntu:/opt/software-discovery-tool$ sudo -u apache ./bin/config_build.py 
Scanning distro_data directory...
Found new file: Ubuntu_16_04_Package_List.json
Found new file: Suse_Linux_Enterprise_Server_12_SP5_Package_List.json
Found new file: RHEL_8_1_Package_List.json
Found new file: SUSE_Package_Hub_SLES_12_SP5.json
Attempting to delete cached_data.json...
Done.
```
### 4. Restart server
```
divya@discoveryubuntu:/opt/software-discovery-tool$ sudo apachectl restart
AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 127.0.1.1. Set the 'ServerName' directive globally to suppress this message
```

Working screenshot :)
![image](https://user-images.githubusercontent.com/42383989/127363316-9f9e431e-c68b-48ba-b0b9-625705aeb55e.png)
