### PR TITLE
Update package_build.py to point to Debian10.11

### DIFF
--- a/bin/package_build.py
+++ b/bin/package_build.py
@@ -17,7 +17,7 @@ def purify(dirty):
 def debian():
 	global DATA, DATA_FILE_LOCATION
 	q = ['Debian_Buster_List.json', 'Debian_Bullseye_List.json']
-	urls = ['http://ftp.debian.org/debian/dists/Debian10.10/main/binary-s390x/Packages.gz', 'http://ftp.debian.org/debian/dists/Debian11.0/main/binary-s390x/Packages.gz']
+	urls = ['http://ftp.debian.org/debian/dists/Debian10.11/main/binary-s390x/Packages.gz', 'http://ftp.debian.org/debian/dists/Debian11.0/main/binary-s390x/Packages.gz']
 	file_name = [f'{DATA_FILE_LOCATION}/{x}' for x in q]
 	for i in range(2):
 		try:


### PR DESCRIPTION
The Debian10.10 directory is gone from ftp.debian.org now that 10.11 has been
released, so updating package_build.py accordingly.

Signed-off-by: Elizabeth K. Joseph <lyz@princessleia.com>