### PR TITLE
Add Fedora 35 to config and FAQ

### DIFF
--- a/src/config/supported_distros.py
+++ b/src/config/supported_distros.py
@@ -14,7 +14,7 @@ SUPPORTED_DISTROS = {
 	'Tumbleweed': 'OpenSUSE_Tumbleweed.json'
 },
 'Fedora': {
-	'Fedora 34': 'Fedora_34_List.json'
+	'Fedora 34': 'Fedora_34_List.json',
 	'Fedora 35': 'Fedora_35_List.json'
 },
 'SUSE Package Hub SLES': {

--- a/src/config/supported_distros.py
+++ b/src/config/supported_distros.py
@@ -15,6 +15,7 @@ SUPPORTED_DISTROS = {
 },
 'Fedora': {
 	'Fedora 34': 'Fedora_34_List.json'
+	'Fedora 35': 'Fedora_35_List.json'
 },
 'SUSE Package Hub SLES': {
 },

--- a/src/static/js/views/faq.html
+++ b/src/static/js/views/faq.html
@@ -29,6 +29,7 @@
             <li>OpenSUSE Tumbleweed</li>
             <li>OpenSUSE Leap 15.3</li>
             <li>Fedora 34</li>
+            <li>Fedora 35</li>
 
         </ul></p>
       </div>


### PR DESCRIPTION
Now that our script has support for it, and the -data repository has been
updated, add Fedora 35 to the configuration file and the FAQ on the website.

Signed-off-by: Elizabeth K. Joseph <lyz@princessleia.com>