### PR TITLE
Updated the debian package list for Debian 11

### DIFF
--- a/bin/package_build.py
+++ b/bin/package_build.py
@@ -17,7 +17,7 @@ def purify(dirty):
 def debian():
 	global DATA, DATA_FILE_LOCATION
 	q = ['Debian_Buster_List.json', 'Debian_Bullseye_List.json']
-	urls = ['http://ftp.debian.org/debian/dists/Debian10.11/main/binary-s390x/Packages.gz', 'http://ftp.debian.org/debian/dists/Debian11.0/main/binary-s390x/Packages.gz']
+	urls = ['http://ftp.debian.org/debian/dists/Debian10.11/main/binary-s390x/Packages.gz', 'http://ftp.debian.org/debian/dists/Debian11.2/main/binary-s390x/Packages.gz']
 	file_name = [f'{DATA_FILE_LOCATION}/{x}' for x in q]
 	for i in range(2):
 		try:


### PR DESCRIPTION
This PR fixes the issue described in #83(fixing the link for Ubuntu 11.2 Bullseye).
Debian package data can now be used successfully (following the instructions that were defined [here](https://github.com/openmainframeproject/software-discovery-tool/blob/master/docs/Installation.md#using-data-from-pds))
![Screenshot from 2022-03-17 16-13-37](https://user-images.githubusercontent.com/62841337/158792708-dcb6590b-2fdc-4ab1-9bc8-0553f2e46e6a.png)
 
If there any changes to be made,I would love to work on them too.
Thanks !

Signed-off-by: Arsh Pratap [arsh31pratap01@gmail.com](mailto:arsh31pratap01@gmail.com)