### PR TITLE
Add support for Fedora 37

### DIFF
--- a/bin/package_build.py
+++ b/bin/package_build.py
@@ -132,7 +132,7 @@ def clefos():
 
 def fedora():
 	global DATA,DATA_FILE_LOCATION
-	sources = [34, 35, 36]
+	sources = [34, 35, 36, 37]
 	pkg_reg = r'<a href="(.*)\.rpm"'
 	dirs = '023456789abcdefghijklmnopqrstuvwxyz'
 	for i in range(len(sources)):

--- a/src/config/supported_distros.py
+++ b/src/config/supported_distros.py
@@ -18,7 +18,9 @@ SUPPORTED_DISTROS = {
 },
 'Fedora': {
 	'Fedora 34': 'Fedora_34_List.json',
-	'Fedora 35': 'Fedora_35_List.json'
+	'Fedora 35': 'Fedora_35_List.json',
+	'Fedora 36': 'Fedora_36_List.json',
+	'Fedora 37': 'Fedora_37_List.json'
 },
 'SUSE Package Hub SLES': {
 },

--- a/src/static/js/views/faq.html
+++ b/src/static/js/views/faq.html
@@ -30,6 +30,8 @@
             <li>OpenSUSE Leap 15.3</li>
             <li>Fedora 34</li>
             <li>Fedora 35</li>
+            <li>Fedora 36</li>
+            <li>Fedora 37</li>
             <li>AlmaLinux 9</li>
 
         </ul></p>


### PR DESCRIPTION
Fedora 37 was released recently so adding support for it. Also noticed Fedora 36 wasn't added to the documentation and supported_distros.py, so added it there too.

Signed-off-by: Elizabeth K. Joseph <lyz@princessleia.com>