### PR TITLE
Seperating out Debian OS versions 10 and 11 in the list present in FAQ

### DIFF
--- a/src/static/js/views/faq.html
+++ b/src/static/js/views/faq.html
@@ -24,7 +24,8 @@
         <p>Currently, Software Discovery Tool contains data for the following operating systems:
         <ul>
             <li>IBM z/OS</li>
-            <li>Debian 10(Buster) and 11(Bullseye)</li>
+            <li>Debian 10(Buster)</li> 
+	    <li>Debian 11(Bullseye)</li>
             <li>ClefOS 7</li>
             <li>OpenSUSE Tumbleweed</li>
             <li>OpenSUSE Leap 15.3</li>


### PR DESCRIPTION
In the FAQ section, I've separated out the Debian OS versions 10 and 11 that were present together as one list item to separate list items. @pleia2 and @arshPratap please take a look and let me know if there's any change I need to make.