### PR TITLE
Adding OpenSUSE 15.5

### DIFF
--- a/bin/package_build.py
+++ b/bin/package_build.py
@@ -51,8 +51,9 @@ def debian():
 def opensuse():
 	source_data = [[f"https://download.opensuse.org/ports/zsystems/tumbleweed/repo/oss/{x}/?jsontable" for x in ['s390x', 'noarch']], 
 		[f"https://download.opensuse.org/distribution/leap/15.3/repo/oss/{x}/?jsontable" for x in ['s390x', 'noarch']], 
-		[f"https://download.opensuse.org/distribution/leap/15.4/repo/oss/{x}/?jsontable" for x in ['s390x', 'noarch']]]
-	q = ['OpenSUSE_Tumbleweed.json', 'OpenSUSE_Leap_15_3.json', 'OpenSUSE_Leap_15_4.json']
+		[f"https://download.opensuse.org/distribution/leap/15.4/repo/oss/{x}/?jsontable" for x in ['s390x', 'noarch']],
+		[f"https://download.opensuse.org/distribution/leap/15.5/repo/oss/{x}/?jsontable" for x in ['s390x', 'noarch']]]
+	q = ['OpenSUSE_Tumbleweed.json', 'OpenSUSE_Leap_15_3.json', 'OpenSUSE_Leap_15_4.json', 'OpenSUSE_Leap_15_5.json']
 	regex_pattern = r"-(.*?)-"
 	for i in range(len(source_data)):
 		opensuse_list= []
@@ -75,7 +76,8 @@ def opensuse():
 						if package_name == None or version == None:
 							continue
 						data_dict = {"packageName": package_name, "description": "","version" :version}
-						opensuse_list.append(data_dict)
+						if data_dict not in opensuse_list:
+							opensuse_list.append(data_dict)
 		file_name = q[i]
 		file_path = f'{DATA_FILE_LOCATION}/{file_name}'
 		with open(file_path, 'w') as file:

--- a/src/config/supported_distros.py
+++ b/src/config/supported_distros.py
@@ -13,10 +13,11 @@ SUPPORTED_DISTROS = {
 'ClefOS': {
 	'ClefOS Base 7': 'ClefOS_7_List.json'
 },
-'OpenSUSE': {
+'openSUSE': {
+    	'Tumbleweed': 'OpenSUSE_Tumbleweed.json',
 	'Leap 15.3': 'OpenSUSE_Leap_15_3.json',
-	'Tumbleweed': 'OpenSUSE_Tumbleweed.json',
-	'Leap 15.4': 'OpenSUSE_Leap_15_4.json'
+	'Leap 15.4': 'OpenSUSE_Leap_15_4.json',
+    	'Leap 15.5': 'OpenSUSE_Leap_15_5.json'
 },
 'Fedora': {
 	'Fedora 34': 'Fedora_34_List.json',

--- a/src/static/js/views/faq.html
+++ b/src/static/js/views/faq.html
@@ -28,9 +28,10 @@
             <li>Debian 11(Bullseye)</li>
             <li>Debian 12(Bookworm)</li>
             <li>ClefOS 7</li>
-            <li>OpenSUSE Tumbleweed</li>
-            <li>OpenSUSE Leap 15.3</li>
-            <li>OpenSUSE Leap 15.4</li>
+            <li>openSUSE Tumbleweed</li>
+            <li>openSUSE Leap 15.3</li>
+            <li>openSUSE Leap 15.4</li>
+            <li>openSUSE Leap 15.5</li>
             <li>Fedora 34</li>
             <li>Fedora 35</li>
             <li>Fedora 36</li>
@@ -43,7 +44,6 @@
             <li>IBM Validated List for Ubuntu 22.04</li>
             <li>AlmaLinux 9</li>
             <li>Rocky Linux 9</li>
-
         </ul></p>
       </div>
       <div class="list-group-item list-group-item-info ng-class:{'active': questionState(3), 'glyphicon-minus':questionState(3), 'glyphicon-plus':!questionState(3)};"  ng-click="clickQuestion(3)">


### PR DESCRIPTION
I've added code for Opensuse 15.5 in package_build. #153 
While creating file for Opensuse 15.5, I noticed there's a lot of entries that are duplicate of one another having same package_name and version. They actually differ in release only #155 therefore slowing down our search and adding redundant entries. Hence, I've also add code for checking if there's an entry with same package name and version. If there is an entry we won't add it to the file else we'll.

![Screenshot from 2023-08-31 00-16-33](https://github.com/openmainframeproject/software-discovery-tool/assets/80761691/09cb18de-136a-4c59-a6bf-2964664a0277)

Please take a look @pleia2 and @arshPratap. I'll also check the added opensuse file, if they contain duplicate or not, If they do I'll just update those files too and add file for Opensuse 15.5.