### PR TITLE
Optimizing code for almaLinux

### DIFF
--- a/bin/package_build.py
+++ b/bin/package_build.py
@@ -159,7 +159,6 @@ def fedora():
 def almaLinux():
 	global DATA,DATA_FILE_LOCATION
 	sources = [9]
-	results = []
 	pkg_reg = r'<a href="(.*)\.rpm"'
 	for i in range(len(sources)):
 		results = []


### PR DESCRIPTION
Declaration of the result array outside the for loop is of no use, as it's already declared inside the "for" loop. As part of Good coding practice, we should remove it.

@pleia2 and @arshPratap, let me know your thoughts.