### PR TITLE
Fix #117: Linting standards for software-developer-tool

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/PyCQA/flake8
+    rev: 3.9.2
+    hooks:
+    -   id: flake8


### PR DESCRIPTION
Fix #117.

This PR introduces the usage of flake8 for this project. I chose Flake8 for this project because our current priority is establishing a strong baseline for code style and catching common errors. Flake8 does this efficiently with minimal overhead. It's also easier for the team to adopt and maintain.  If the project grows significantly in complexity, we can always consider integrating a more comprehensive linter like Pylint in the future.