### PR TITLE
Add 8 May 2024 meeting minutes

### DIFF
--- a/meetings/2024-04-03.md
+++ b/meetings/2024-04-03.md
@@ -1,4 +1,4 @@
-# Team Meeting - 3 Apri 2024
+# Team Meeting - 3 April 2024
 
 ### Public link to recording:
 https://zoom.us/rec/share/fXUrk9XANdTPVTZ4MzM6CsVa5JPFnmpTRetf_KWwcyRvMp5GI7mviZ2h7bpY_6mN.5ehDz5A4Hw_Rk8pg
@@ -10,7 +10,7 @@ https://zoom.us/rec/share/fXUrk9XANdTPVTZ4MzM6CsVa5JPFnmpTRetf_KWwcyRvMp5GI7mviZ
  - Prince Singh
  - Divya Goswami
 
-## Agendaa
+## Agenda
  - Current state of the tool
    - Arsh suggested we may want to have the ability to search by package type (ie database) rather than specific names, in case a user isn’t sure exactly what they might need.
      - We should keep this in mind for the UI changes, we want flexibility for other search parameters

--- a/meetings/2024-05-08.md
+++ b/meetings/2024-05-08.md
@@ -1,0 +1,27 @@
+# Team Meeting - 8 May 2024
+
+### Public link to recording:
+https://zoom.us/rec/share/BcAf2gMbwVMYKJNNuqGAmwzD9m7mVLtrnFKRdYXmyGl3sdh93hwmUnylLBFbpvik.f8aipMZvFKk5hBDz
+
+## Attendees:
+
+ - Elizabeth K. Joseph
+ - Divya Goswami
+ - Annay Paul
+ - Apurv Sonawane
+ - Ashwath Kannan
+ - loveth omokaro
+ - Maira Usman
+ - Savar Bhasin
+ - Shivam Verma
+
+## Agenda
+
+ - Project overview and participant introductions
+ - Mentorship program status
+ - Overview of mentorship task outlined here: https://mentorship.lfx.linuxfoundation.org/project/ea44ab21-8b14-4d17-91de-d7a8724483f8
+ - Documentation proposal outlined here: https://github.com/Apurv428/software-discovery-tool-docs
+   - Agreed to move forward with Apurv's sharethedocs.org proposal, Lyz will follow-up directly on how we implement
+ - Linting standards: https://github.com/openmainframeproject/software-discovery-tool/pull/178
+   - Agreed upon Flake8
+ - Issue review


### PR DESCRIPTION
Added minutes and link to recording for our meeting on 8 May 2024, and fix up a couple typos in the April meeting minutes.