### PR TITLE
Update supported_distros.py with current listing

### DIFF
--- a/src/config/supported_distros.py
+++ b/src/config/supported_distros.py
@@ -1,23 +1,23 @@
 SUPPORTED_DISTROS = {
 'IBM z/OS ™': {
-	'z/OS Software': 'ZOS_Software_List'
+	'z/OS Miscellaneous Software': 'ZOS_Software_List'
+	'z/OS Rocket Software': 'ZOS_Rocket_Software.json',
+	'z/OS Open Mainframe Project': 'ZOS_OMP.json',
+	'z/OS from IBM-Z-zOS': 'IBM_Z_zOS.json'
 },
 'IBM Z and LinuxONE Container Registry': {
 	'Container Images for IBM Z and LinuxONE': 'IBMZ_container_registry'
 },
 'Debian': {
-	'10(Buster)': 'Debian_Buster_List',
 	'11(Bullseye)': 'Debian_Bullseye_List',
-    	'12(Bookworm)': 'Debian_Bookworm_List'
+	'12(Bookworm)': 'Debian_Bookworm_List'
 },
 'ClefOS': {
 	'ClefOS Base 7': 'ClefOS_7_List'
 },
 'openSUSE': {
-    	'Tumbleweed': 'OpenSUSE_Tumbleweed',
-	'Leap 15.3': 'OpenSUSE_Leap_15_3',
-	'Leap 15.4': 'OpenSUSE_Leap_15_4',
-  'Leap 15.5': 'OpenSUSE_Leap_15_5'
+	'Tumbleweed': 'OpenSUSE_Tumbleweed',
+	'Leap 15.5': 'OpenSUSE_Leap_15_5'
 },
 'Fedora': {
 	'Fedora 38': 'Fedora_38_List',
@@ -39,11 +39,11 @@ SUPPORTED_DISTROS = {
 	'RockyLinux 9': 'RockyLinux_9_List'
 },
 'IBM Z Validated': {
-    'IBM Z Validated RHEL 8': 'IBM_Validated_OSS_List_RHEL_8',
-    'IBM Z Validated RHEL 9': 'IBM_Validated_OSS_List_RHEL_9',
-    'IBM Z Validated SLES 12': 'IBM_Validated_OSS_List_SLES_12',
-    'IBM Z Validated SLES 15': 'IBM_Validated_OSS_List_SLES_15',
-    'IBM Z Validated Ubuntu 20.04': 'IBM_Validated_OSS_List_Ubuntu_2004',
-    # 'IBM Z Validated Ubuntu 22.04': 'IBM_Validated_OSS_List_Ubuntu_2204'  ---- will be added soon
+	'IBM Z Validated RHEL 8': 'IBM_Validated_OSS_List_RHEL_8',
+	'IBM Z Validated RHEL 9': 'IBM_Validated_OSS_List_RHEL_9',
+	'IBM Z Validated SLES 12': 'IBM_Validated_OSS_List_SLES_12',
+	'IBM Z Validated SLES 15': 'IBM_Validated_OSS_List_SLES_15',
+	'IBM Z Validated Ubuntu 20.04': 'IBM_Validated_OSS_List_Ubuntu_2004',
+	'IBM Z Validated Ubuntu 22.04': 'IBM_Validated_OSS_List_Ubuntu_2204'
 }
 }


### PR DESCRIPTION
We've removed support from some older Linux distributions and split out several of the z/OS files, so this should be reflected in our supported_distros.py file.