### PR TITLE
Remove .json references in supported_distros.py.example

### DIFF
--- a/src/config/supported_distros.py.example
+++ b/src/config/supported_distros.py.example
@@ -1,9 +1,6 @@
 SUPPORTED_DISTROS = {
 'IBM z/OS ™': {
-	'z/OS Miscellaneous Software': 'ZOS_Software_List',
-	'z/OS Rocket Software': 'ZOS_Rocket_Software.json',
-	'z/OS Open Mainframe Project': 'ZOS_OMP.json',
-	'z/OS from IBM-Z-zOS': 'IBM_Z_zOS.json'
+	'z/OS Miscellaneous Software': 'ZOS_Software_List'
 },
 'IBM Z and LinuxONE Container Registry': {
 	'Container Images for IBM Z and LinuxONE': 'IBMZ_container_registry'


### PR DESCRIPTION
This PR removes the carried over `.json` references in `supported_distros.py.example` for proper functioning of the tool. 
Fixes #216 