### PR TITLE
Update FAQ to remove unsupported distros

### DIFF
--- a/src/static/js/views/faq.html
+++ b/src/static/js/views/faq.html
@@ -24,13 +24,10 @@
         <p>Currently, Software Discovery Tool contains data for the following operating systems:
         <ul>
             <li>IBM z/OS</li>
-            <li>Debian 10(Buster)</li>
-            <li>Debian 11(Bullseye)</li>
-            <li>Debian 12(Bookworm)</li>
+            <li>Debian 11 (Bullseye)</li>
+            <li>Debian 12 (Bookworm)</li>
             <li>ClefOS 7</li>
             <li>openSUSE Tumbleweed</li>
-            <li>openSUSE Leap 15.3</li>
-            <li>openSUSE Leap 15.4</li>
             <li>openSUSE Leap 15.5</li>
             <li>openSUSE Leap 15.6</li>
             <li>Fedora 38</li>


### PR DESCRIPTION
Remove old versions of Debian and openSUSE that the script no longer generates sources for.