### PR TITLE
fix: pin serialize-javascript to 6.0.2 for Node.js 18 compatibility

### DIFF
--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -15775,14 +15775,6 @@
         "node": ">= 10.13.0"
       }
     },
-    "node_modules/rollup-plugin-terser/node_modules/serialize-javascript": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
-      "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -48,5 +48,8 @@
   },
   "devDependencies": {
     "tailwindcss": "^3.4.4"
+  },
+  "overrides": {
+    "serialize-javascript": "6.0.2"
   }
 }


### PR DESCRIPTION
- Pins `serialize-javascript` to `6.0.2` via npm `overrides` in `react-frontend/package.json`
- `serialize-javascript` >=6.0.3 uses `crypto.getRandomValues()` as a global, which is only 
  available natively in Node.js 19+
- Ubuntu 24.04 ships with Node.js 18.19.1, causing a `ReferenceError: crypto is not defined` 
  at startup