### PR TITLE
fix: add repo column support to database_build.js

### DIFF
--- a/bin/database_build.js
+++ b/bin/database_build.js
@@ -54,7 +54,7 @@ async function jsonToSql(connection, table, file, osName) {
       item.packageName,
       item.version,
       item.description || null,
-      item.repo || null,
+      item.repo ? [...new Set(item.repo.split(','))].join(',') : null,
       osName
     ]);
 

--- a/bin/database_build.js
+++ b/bin/database_build.js
@@ -32,6 +32,7 @@ async function createTable(connection, tblname) {
     packageName VARCHAR(100) NOT NULL,
     version VARCHAR(500) NOT NULL,
     description VARCHAR(500),
+    repo VARCHAR(500),
     osName VARCHAR(100) NOT NULL,
     PRIMARY KEY (pkgId)
   )`;
@@ -53,6 +54,7 @@ async function jsonToSql(connection, table, file, osName) {
       item.packageName,
       item.version,
       item.description || null,
+      item.repo || null,
       osName
     ]);
 
@@ -61,7 +63,7 @@ async function jsonToSql(connection, table, file, osName) {
     return;
   }
 
-  const query = `INSERT INTO \`${table}\` (packageName, version, description, osName) VALUES ?`;
+  const query = `INSERT INTO \`${table}\` (packageName, version, description, repo, osName) VALUES ?`;
   await connection.query(query, [finalData]);
   console.log(`${table} : Entries filled`);
 }


### PR DESCRIPTION
Port the repo field fix from database_build.py (PR #289) to the new Node.js database build script. PDS JSON sources now include a repo field; this adds a repo VARCHAR(500) column to all tables and inserts the value (or null) during import.

