### PR TITLE
fix: update distros.json for Linux data source clean-up (Apr 2026)

### DIFF
--- a/config/distros.json
+++ b/config/distros.json
@@ -9,38 +9,37 @@
     "Container Images for IBM Z and LinuxONE": "IBMZ_container_registry"
   },
   "Debian": {
-    "11(Bullseye)": "Debian_Bullseye_List",
-    "12(Bookworm)": "Debian_Bookworm_List"
+    "12(Bookworm)": "Debian_Bookworm_List",
+    "13(Trixie)": "Debian_Trixie_List"
   },
   "ClefOS": {
     "ClefOS Base 7": "ClefOS_7_List"
   },
   "openSUSE": {
     "Tumbleweed": "OpenSUSE_Tumbleweed",
-    "Leap 15.5": "OpenSUSE_Leap_15_5",
-    "Leap 15.6": "OpenSUSE_Leap_15_6"
+    "Leap 15.6": "OpenSUSE_Leap_15_6",
+    "Leap 16.0": "OpenSUSE_Leap_16_0"
   },
   "Fedora": {
-    "Fedora 38": "Fedora_38_List",
-    "Fedora 39": "Fedora_39_List",
-    "Fedora 40": "Fedora_40_List"
+    "Fedora 42": "Fedora_42_List",
+    "Fedora 43": "Fedora_43_List"
   },
   "SUSE Package Hub SLES": {},
   "Suse Linux Enterprise Server": {},
   "Ubuntu": {},
   "RHEL": {},
   "Alma Linux": {
-    "Alma Linux 9": "AlmaLinux_9_List"
+    "Alma Linux 9": "AlmaLinux_9_List",
+    "Alma Linux 10": "AlmaLinux_10_List"
   },
   "Rocky Linux": {
-    "RockyLinux 9": "RockyLinux_9_List"
+    "RockyLinux 9": "RockyLinux_9_List",
+    "RockyLinux 10": "RockyLinux_10_List"
   },
   "IBM Z Validated": {
-    "IBM Z Validated RHEL 8": "IBM_Validated_OSS_List_RHEL_8",
     "IBM Z Validated RHEL 9": "IBM_Validated_OSS_List_RHEL_9",
-    "IBM Z Validated SLES 12": "IBM_Validated_OSS_List_SLES_12",
     "IBM Z Validated SLES 15": "IBM_Validated_OSS_List_SLES_15",
-    "IBM Z Validated Ubuntu 20.04": "IBM_Validated_OSS_List_Ubuntu_2004",
-    "IBM Z Validated Ubuntu 22.04": "IBM_Validated_OSS_List_Ubuntu_2204"
+    "IBM Z Validated Ubuntu 22.04": "IBM_Validated_OSS_List_Ubuntu_2204",
+    "IBM Z Validated Ubuntu 24.04": "IBM_Validated_OSS_List_Ubuntu_2404"
   }
 }


### PR DESCRIPTION
Remove EOL distributions and add new releases per issue #76:

Remove:
- Debian 11 (Bullseye)
- Fedora 38, 39, 40
- openSUSE Leap 15.5
- IBM Z Validated RHEL 8, SLES 12, Ubuntu 20.04

Add:
- Debian 13 (Trixie)
- Fedora 42, 43
- openSUSE Leap 16.0
- Alma Linux 10
- Rocky Linux 10
- IBM Z Validated Ubuntu 24.04

Refs: openmainframeproject/software-discovery-tool-data#76