### PR TITLE
 add UI support for repo field in search results

### DIFF
--- a/react-frontend/src/App.css
+++ b/react-frontend/src/App.css
@@ -739,6 +739,15 @@ input:focus {
   border-radius: 4px;
   font-size: 12px;
 }
+.repo-tag {
+  background-color: #9333ea;
+  color: white;
+  padding: 5px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  text-decoration: none;
+  cursor: pointer;
+}
 
 .content {
   display: flex;

--- a/react-frontend/src/components/SearchBar.jsx
+++ b/react-frontend/src/components/SearchBar.jsx
@@ -104,7 +104,8 @@ function SearchBar({ onSearchPerformed }) {
           packageName: pkg.packageName,
           description: pkg.description || 'No description available',
           version: pkg.version || 'No version information',
-          ostag: pkg.osName || 'No OSTag information'
+          ostag: pkg.osName || 'No OSTag information',
+          repo: pkg.repo || null
         }));
         setResults(transformedResults);
         setTotalResultsCount(data.total_packages || 0);

--- a/react-frontend/src/components/SearchBar.jsx
+++ b/react-frontend/src/components/SearchBar.jsx
@@ -17,6 +17,7 @@ const normalizeApiBaseUrl = (rawUrl) => {
 function SearchBar({ onSearchPerformed }) {
   const [input, setInput] = useState("");
   const [searchDescription, setSearchDescription] = useState(true);
+  const [showRepo, setShowRepo] = useState(false);
   const [results, setResults] = useState([]);
   const [searchPerformed, setSearchPerformed] = useState(false);
   const [itemsPerPage, setItemsPerPage] = useState(10);
@@ -262,6 +263,17 @@ function SearchBar({ onSearchPerformed }) {
           Search Description
         </label>
       </div>
+      <div className="flex justify-center mt-2">
+        <label className="flex items-center">
+          <input
+            type="checkbox"
+            checked={showRepo}
+            onChange={() => setShowRepo(!showRepo)}
+            className="mr-2"
+          />
+          Show Repository
+        </label>
+      </div>
 
       <div className="text-center mt-2 font-bold">
         Enter the name of the package or at least three characters to enable pattern search. Wildcard ('*') can be used either before or after the search keywords.
@@ -311,7 +323,8 @@ function SearchBar({ onSearchPerformed }) {
       ) : (
         <SearchResults 
           results={results} 
-          showDesc={searchDescription} 
+          showDesc={searchDescription}
+          showRepo={showRepo} 
           itemsPerPage={itemsPerPage} 
           searchPerformed={searchPerformed} 
           totalResultsCount={totalResultsCount}

--- a/react-frontend/src/components/SearchResults.jsx
+++ b/react-frontend/src/components/SearchResults.jsx
@@ -74,6 +74,16 @@ function SearchResults({
                   {result.ostag}
                 </div>
               )}
+              {result.repo && (
+                
+                 <a href={result.repo}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="repo-tag"
+                >
+                  Validated
+                </a>
+              )}
             </div>
             <div className="content">
               <div className="name">{result.packageName}</div>

--- a/react-frontend/src/components/SearchResults.jsx
+++ b/react-frontend/src/components/SearchResults.jsx
@@ -6,6 +6,7 @@ import '../App.css';
 function SearchResults({
   results = [],
   showDesc,
+  showRepo,
   itemsPerPage,
   searchPerformed,
   totalResultsCount,
@@ -74,15 +75,11 @@ function SearchResults({
                   {result.ostag}
                 </div>
               )}
-              {result.repo && (
-                
-                 <a href={result.repo}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="repo-tag"
-                >
-                  Validated
-                </a>
+              
+            {result.repo && showRepo && (
+                <span className="repo-tag" title={result.repo}>
+                  {result.repo}
+                </span>
               )}
             </div>
             <div className="content">


### PR DESCRIPTION
## Summary
Closes #265

Adds optional UI support for the `repo` field now present 
in PDS data sources.

## Changes Made

### `bin/database_build.py`
- Added `repo` column to MySQL table schema in `createTable()`
- Updated `jsontosql()` to handle all INSERT cases

### `src/classes/package_search.py`
- Added `repo` to both SELECT queries in `searchSQLPackages()`

### `src/static/js/views/home.html`
- Added optional "Show Repository" checkbox
- Added Repository column — shows clickable link when repo 
  exists, shows `—` when absent