### PR TITLE
ci: add npm audit CI check for react-frontend security

### DIFF
--- a/.github/workflows/frontend-security-audit.yml
+++ b/.github/workflows/frontend-security-audit.yml
@@ -1,0 +1,38 @@
+name: Frontend Security Audit
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'react-frontend/**'
+  pull_request:
+    paths:
+      - 'react-frontend/**'
+
+permissions:
+  contents: read
+
+jobs:
+  npm-audit:
+    name: npm audit (high and critical)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: react-frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: react-frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run security audit
+        run: npm audit --audit-level=high --omit=dev

--- a/docs/Contribute.md
+++ b/docs/Contribute.md
@@ -36,6 +36,16 @@ git push origin Software-Discovery-Tool-feature_name
 
 For more information on creating a pull request, refer to the [GitHub Help documentation](https://help.github.com/articles/creating-a-pull-request/).
 
+## Security Policy for React Frontend
+
+All pull requests that modify files under `react-frontend/` are subject
+to an automated security audit via GitHub Actions. The CI pipeline runs `npm audit --audit-level=high` and will fail CI if any high or critical severity vulnerabilities are introduced, which may block merging when required checks are enforced.
+
+If your PR fails this check:
+1. Run `npm audit` locally inside `react-frontend/` to see the issues.
+2. Run `npm audit fix` to auto-fix what's safe.
+3. For issues that can't be auto-fixed, update the affected dependency manually or open a separate issue.
+
 ## Note
 
 Please note that not all pull requests may be accepted. The project maintainers will review your changes and determine their suitability for merging into the main branch. If your contribution is not accepted, the reviewer will provide feedback and explain the reason.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/frontend-security-audit.yml` that runs `npm audit --audit-level=high --omit=dev` on all PRs and pushes that touch `react-frontend/`
- Uses Node 22 to match the project's NodeSource requirement
- Documents the security policy in `docs/Contribute.md`

This is a clean rebase of @TusharB-07's work in #288, rebased on master after the Vite migration (PR #291) and updated to Node 22. All credit for the original implementation goes to @TusharB-07.

Closes #285

## Test plan

- [ ] Open a PR that touches `react-frontend/` and verify the `Frontend Security Audit` check runs
- [ ] Confirm `npm audit --audit-level=high` passes on the current codebase