### PR TITLE
feat: add filter distribution sidebar with per-version selection

### DIFF
--- a/react-frontend/src/App.css
+++ b/react-frontend/src/App.css
@@ -852,3 +852,131 @@ input:focus {
 .refine-filters label:not(:last-child) {
   margin-bottom: 15px;
 }
+
+.results-layout {
+  display: flex;
+  gap: 24px;
+  width: 100%;
+  align-items: flex-start;
+  padding: 0 10px;
+}
+
+.filter-sidebar {
+  flex: 0 0 240px;
+  background-color: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 16px;
+  position: sticky;
+  top: 20px;
+}
+
+.filter-sidebar .refine-filters {
+  margin-bottom: 20px;
+  text-align: left;
+}
+
+.filter-sidebar .refine-filters label {
+  display: block;
+  margin-bottom: 8px;
+  font-weight: 600;
+  color: #333;
+  font-size: 14px;
+}
+
+.filter-sidebar .refine-filters input {
+  width: 100%;
+  padding: 8px 10px;
+  margin-top: 6px;
+  box-sizing: border-box;
+  border: 1px solid #ccc;
+  border-radius: 6px;
+}
+
+.filter-sidebar .refine-filters input[type="text"]:focus {
+  border-color: #044fc0;
+  outline: none;
+}
+
+.filter-heading {
+  font-weight: 700;
+  font-size: 14px;
+  color: #333;
+  margin-bottom: 10px;
+}
+
+.distro-group {
+  margin-bottom: 4px;
+}
+
+.distro-group-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 4px;
+  font-weight: 600;
+  font-size: 14px;
+  cursor: pointer;
+  color: #333;
+  user-select: none;
+}
+
+.distro-group-header:hover {
+  color: #044fc0;
+}
+
+.distro-versions {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-left: 18px;
+}
+
+.version-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  padding: 4px 0;
+  cursor: pointer;
+  color: #444;
+}
+
+.version-checkbox-row input {
+  cursor: pointer;
+}
+
+.clear-filters-btn {
+  width: 100%;
+  margin-top: 16px;
+  padding: 8px;
+  background-color: #ffffff;
+  border: 1px solid #044fc0;
+  color: #044fc0;
+  border-radius: 6px;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.clear-filters-btn:hover {
+  background-color: #044fc0;
+  color: #ffffff;
+}
+
+.results-main {
+  flex: 1;
+  min-width: 0;
+}
+
+@media (max-width: 768px) {
+  .results-layout {
+    flex-direction: column;
+  }
+
+  .filter-sidebar {
+    flex: 1 1 auto;
+    width: 100%;
+    position: static;
+  }
+}

--- a/react-frontend/src/components/FilterSidebar/FilterSidebar.jsx
+++ b/react-frontend/src/components/FilterSidebar/FilterSidebar.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+function FilterSidebar({
+    osList,
+    expandedOS,
+    onToggleExpand,
+    selectedVersions,
+    onVersionToggle,
+    refinePackageName,
+    onRefineChange,
+    onClearFilters
+}) {
+    return (
+        <div className="filter-sidebar">
+            <div className="refine-filters">
+                <label>
+                    Refine results on this page
+                    <input
+                        type="text"
+                        value={refinePackageName}
+                        onChange={(e) => onRefineChange(e.target.value)}
+                        placeholder="Search within page..."
+                        className="ml-2 p-1 border rounded"
+                    />
+                </label>
+            </div>
+
+            <div className="filter-distribution">
+                <p className="filter-heading">Filter distribution</p>
+                {Object.keys(osList).map((os) => (
+                    <div key={os} className="distro-group">
+                        <div
+                            className="distro-group-header"
+                            onClick={() => onToggleExpand(os)}
+                        >
+                            <span>{expandedOS[os] ? '▾' : '▸'}</span> {os}
+                        </div>
+                        {expandedOS[os] && (
+                            <div className="distro-versions">
+                                {Object.keys(osList[os]).map((version) => (
+                                    <label key={version} className="version-checkbox-row">
+                                        <input
+                                            type="checkbox"
+                                            checked={!!(selectedVersions[os] && selectedVersions[os][version])}
+                                            onChange={() => onVersionToggle(os, version)}
+                                        />
+                                        {version}
+                                    </label>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                ))}
+            </div>
+
+            <button className="clear-filters-btn" onClick={onClearFilters}>
+                Clear filters
+            </button>
+        </div>
+    );
+}
+
+export default FilterSidebar;

--- a/react-frontend/src/components/SearchBar.jsx
+++ b/react-frontend/src/components/SearchBar.jsx
@@ -1,4 +1,5 @@
 /* global BigInt */
+import FilterSidebar from './FilterSidebar/FilterSidebar';
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import omfLogo from "../images/openmainframe-logo.png";
 import SearchResults from './SearchResults.jsx';
@@ -21,8 +22,9 @@ function SearchBar({ onSearchPerformed }) {
   const [searchPerformed, setSearchPerformed] = useState(false);
   const [itemsPerPage, setItemsPerPage] = useState(10);
   const [osList, setOsList] = useState({});
-  const [selectedOS, setSelectedOS] = useState({});
-  const [selectAll, setSelectAll] = useState(false);
+  const [selectedVersions, setSelectedVersions] = useState({});
+  const [expandedOS, setExpandedOS] = useState({});
+  const [refinePackageName, setRefinePackageName] = useState('');
   const [loading, setLoading] = useState(false);
   const [totalResultsCount, setTotalResultsCount] = useState(0);
   const [currentPage, setCurrentPage] = useState(0);
@@ -53,32 +55,26 @@ function SearchBar({ onSearchPerformed }) {
   }, [fetchOSList]);
 
   useEffect(() => {
-    const updatedSelectedOS = Object.keys(osList).reduce((acc, os) => {
-      acc[os] = selectAll;
-      return acc;
-    }, {});
-    setSelectedOS(updatedSelectedOS);
-  }, [selectAll, osList]);
-
-  useEffect(() => {
     onSearchPerformed(searchPerformed);
   }, [searchPerformed, onSearchPerformed]);
 
   useEffect(() => {
     if (searchPerformed) {
-      setNoDistributionMessage(!Object.values(selectedOS).some(Boolean));
+      const anySelected = Object.values(selectedVersions).some(versions =>
+        Object.values(versions).some(Boolean)
+      );
+      setNoDistributionMessage(!anySelected);
     }
-  }, [selectedOS, searchPerformed]);
+  }, [selectedVersions, searchPerformed]);
 
   const generateSearchBitFlag = () => {
     let searchBitFlag = 0n;
-    Object.entries(selectedOS).forEach(([os, selected]) => {
-      if (selected) {
-        const osVersions = osList[os];
-        Object.values(osVersions).forEach(bitValue => {
-          searchBitFlag |= BigInt(bitValue);
-        });
-      }
+    Object.entries(selectedVersions).forEach(([os, versions]) => {
+      Object.entries(versions).forEach(([version, isSelected]) => {
+        if (isSelected) {
+          searchBitFlag |= BigInt(osList[os][version]);
+        }
+      });
     });
     return searchBitFlag.toString();
   };
@@ -166,21 +162,26 @@ function SearchBar({ onSearchPerformed }) {
     }
   };
 
-  const handleOSCheckboxChange = (os) => {
-    setSelectedOS(prev => {
-      const updated = { ...prev, [os]: !prev[os] };
-      const selectedParents = Object.keys(updated).filter(key => updated[key]);
+  const toggleExpand = (os) => {
+    setExpandedOS(prev => ({ ...prev, [os]: !prev[os] }));
+  };
+
+  const handleVersionToggle = (os, version) => {
+    setSelectedVersions(prev => {
+      const osVersions = { ...(prev[os] || {}) };
+      osVersions[version] = !osVersions[version];
+      const updated = { ...prev, [os]: osVersions };
+      const selectedParents = Object.keys(updated).filter(o =>
+        Object.values(updated[o]).some(Boolean)
+      );
       setSelectedParentDistributions(selectedParents);
       return updated;
     });
   };
 
-  const handleSelectAllChange = () => {
-    setSelectAll(prev => {
-      const newSelectAll = !prev;
-      setSelectedParentDistributions(newSelectAll ? Object.keys(osList) : []);
-      return newSelectAll;
-    });
+  const handleClearFilters = () => {
+    setSelectedVersions({});
+    setSelectedParentDistributions([]);
   };
 
   return (
@@ -217,33 +218,6 @@ function SearchBar({ onSearchPerformed }) {
         </div>
       </div>
 
-      <div className="flex flex-wrap justify-center os-checkbox-wrapper mt-4">
-        <div className="os-checkbox-container">
-          <label>
-            <input
-              type="checkbox"
-              checked={selectAll}
-              onChange={handleSelectAllChange}
-              className="mr-2"
-            />
-            All
-          </label>
-        </div>
-        {Object.keys(osList).map((os, index) => (
-          <div key={index} className="os-checkbox-container">
-            <label>
-              <input
-                type="checkbox"
-                checked={selectedOS[os] || false}
-                onChange={() => handleOSCheckboxChange(os)}
-                className="mr-2"
-              />
-              {os}
-            </label>
-          </div>
-        ))}
-      </div>
-
       {searchPerformed && noDistributionMessage && (
         <div className="text-center text-red-500 mt-2">
           No distribution selected
@@ -272,54 +246,65 @@ function SearchBar({ onSearchPerformed }) {
         </div>
       )}
 
-      <div className="results-count text-center sm:text-left">
-        {searchPerformed ? (
-          totalResultsCount > 0 ? (
-            `${totalResultsCount} package${totalResultsCount !== 1 ? 's' : ''} found`
-          ) : (
-            '0 packages found'
-          )
-        ) : (
-          ''
-        )}
-      </div>
+      {searchPerformed && (
+        <div className="results-layout">
+          <FilterSidebar
+            osList={osList}
+            expandedOS={expandedOS}
+            onToggleExpand={toggleExpand}
+            selectedVersions={selectedVersions}
+            onVersionToggle={handleVersionToggle}
+            refinePackageName={refinePackageName}
+            onRefineChange={setRefinePackageName}
+            onClearFilters={handleClearFilters}
+          />
+          <div className="results-main">
+            <div className="results-count text-center sm:text-left">
+              {totalResultsCount > 0
+                ? `${totalResultsCount} package${totalResultsCount !== 1 ? 's' : ''} found`
+                : '0 packages found'}
+            </div>
 
-      {totalResultsCount > 5 && (
-        <div className="records-per-page mt-2 flex justify-center sm:justify-start items-center">
-          <label className="text-sm">
-            Records per page:
-            <select
-              value={itemsPerPage}
-              onChange={handleItemsPerPageChange}
-              className="ml-2 p-1 border rounded text-sm"
-            >
-              {[5, 10, 20, 30, 40, 50]
-                .filter((count) => count <= totalResultsCount || count === 5)
-                .map((count) => (
-                  <option key={count} value={count}>
-                    {count}
-                  </option>
-                ))}
-            </select>
-          </label>
+            {totalResultsCount > 5 && (
+              <div className="records-per-page mt-2 flex justify-center sm:justify-start items-center">
+                <label className="text-sm">
+                  Records per page:
+                  <select
+                    value={itemsPerPage}
+                    onChange={handleItemsPerPageChange}
+                    className="ml-2 p-1 border rounded text-sm"
+                  >
+                    {[5, 10, 20, 30, 40, 50]
+                      .filter((count) => count <= totalResultsCount || count === 5)
+                      .map((count) => (
+                        <option key={count} value={count}>
+                          {count}
+                        </option>
+                      ))}
+                  </select>
+                </label>
+              </div>
+            )}
+
+            {loading ? (
+              <div className="text-center mt-4">Loading...</div>
+            ) : (
+              <SearchResults
+                results={results}
+                showDesc={searchDescription}
+                itemsPerPage={itemsPerPage}
+                searchPerformed={searchPerformed}
+                totalResultsCount={totalResultsCount}
+                selectedParentDistributions={selectedParentDistributions}
+                osList={osList}
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={handlePageChange}
+                refinePackageName={refinePackageName}
+              />
+            )}
+          </div>
         </div>
-      )}
-
-      {loading ? (
-        <div className="text-center mt-4">Loading...</div>
-      ) : (
-        <SearchResults 
-          results={results} 
-          showDesc={searchDescription} 
-          itemsPerPage={itemsPerPage} 
-          searchPerformed={searchPerformed} 
-          totalResultsCount={totalResultsCount}
-          selectedParentDistributions={selectedParentDistributions}
-          osList={osList}
-          currentPage={currentPage}
-          totalPages={totalPages}
-          onPageChange={handlePageChange}
-        />
       )}
     </div>
   );

--- a/react-frontend/src/components/SearchResults.jsx
+++ b/react-frontend/src/components/SearchResults.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import ReactPaginate from 'react-paginate';
 import ArrowUpwardIcon from '@mui/icons-material/ArrowUpward';
 import '../App.css';
@@ -13,10 +13,9 @@ function SearchResults({
   osList,
   currentPage,
   totalPages,
-  onPageChange
+  onPageChange,
+  refinePackageName
 }) {
-  const [refinePackageName, setRefinePackageName] = useState('');
-
   const filteredResults = useMemo(() => {
     if (!Array.isArray(results)) return [];
     if (!refinePackageName.trim()) return results;
@@ -43,23 +42,6 @@ function SearchResults({
 
   return (
     <div className="search-results-container">
-      {searchPerformed && results.length > 0 && (
-        <div className="refine-filters-container">
-          <div className="refine-filters">
-            <label>
-              Refine results on this page:
-              <input
-                type="text"
-                value={refinePackageName}
-                onChange={(e) => setRefinePackageName(e.target.value)}
-                placeholder="Search within page..."
-                className="ml-2 p-1 border rounded"
-              />
-            </label>
-          </div>
-        </div>
-      )}
-
       <div className="search-list-container">
         {filteredResults.map((result, index) => (
           <div key={index} className="search-list">


### PR DESCRIPTION
Closes #321

## Summary
Adds a "Filter distribution" section to the sidebar, allowing users to filter search results by specific point-release versions within a distro family (e.g. Debian 12 vs 11), rather than only by parent distribution.

## Changes
- New `FilterSidebar` component: collapsible distro groups with per-version checkboxes, plus the "Refine results on this page" search moved here from the results panel (per @pleia2's feedback on the mock-up).
- `SearchBar`: replaced flat parent-distro checkbox state with per-version state (`selectedVersions`), and bit-flag generation now sums selected version flags directly.
- `SearchResults`: removed local refine-input state, now receives `refinePackageName` as a prop from the shared sidebar.

## Testing
Verified locally with mock distro data — sidebar renders, groups expand/collapse independently, checkbox selection clears "No distribution selected" warning correctly. Full end-to-end search flow needs a live backend to verify against.

@pleia2 ready for review — this follows the mock-up you approved.