### PR TITLE
docs: add production installation guide for Ubuntu 24.04

### DIFF
--- a/docs/Installation.md
+++ b/docs/Installation.md
@@ -2,19 +2,33 @@
 
 ## Steps for setting up software-discovery-tool application on server
 
-The instructions provided below specify the steps for Ubuntu 20.04/22.04/24.04:
+The instructions provided below specify the steps for Ubuntu 24.04:
 
 _**NOTE:**_
 * make sure you are logged in as user with sudo permissions
 
 ### Step 1: Install prerequisites
 
-System prerequisites
+#### Install Node.js 22 via NodeSource
+
+Ubuntu 24.04's default apt package provides Node.js 18, which is too old for Vite 8 (requires Node 20.19+ or 22). Install Node.js 22 LTS from NodeSource:
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt-get install -y nodejs
+```
+
+Verify:
+```bash
+node --version   # Should print v22.x.x
+```
+
+#### Install remaining system dependencies
 
 ```bash
 sudo apt update
 sudo apt dist-upgrade
-sudo apt install nodejs npm git mariadb-server
+sudo apt install git mariadb-server
 # Python is only required if you plan to use bin/package_build.py
 sudo apt install python3 python3-requests
 ```

--- a/docs/Production_Installation.md
+++ b/docs/Production_Installation.md
@@ -1,0 +1,307 @@
+# Production Installation
+
+This guide covers deploying the Software Discovery Tool as a production service on Ubuntu 24.04 using Apache2 as the web server. For a developer setup, see [Installation.md](Installation.md).
+
+## Overview
+
+The production deployment has two components:
+- **Node.js backend** — runs as a systemd service on port 5000
+- **React frontend** — compiled to static files and served by Apache2
+
+## Prerequisites
+
+- Ubuntu 24.04 server with sudo access
+- Domain name or IP address for the server
+
+---
+
+## Step 1: Install Node.js 22 (via NodeSource)
+
+Ubuntu 24.04's apt ships Node.js 18 which is too old for Vite 8 (requires Node 20.19+ or 22). Install Node.js 22 LTS from NodeSource:
+
+```bash
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt-get install -y nodejs
+```
+
+Verify the installation:
+
+```bash
+node --version   # Should print v22.x.x
+npm --version
+```
+
+---
+
+## Step 2: Install system dependencies
+
+```bash
+sudo apt update
+sudo apt dist-upgrade
+sudo apt install git apache2 mariadb-server python3 python3-requests
+```
+
+---
+
+## Step 3: Clone the repository
+
+```bash
+git clone https://github.com/openmainframeproject/software-discovery-tool.git
+cd software-discovery-tool
+git submodule update --init --recursive
+```
+
+---
+
+## Step 4: Set up MariaDB
+
+### Secure the installation
+
+```bash
+sudo mariadb-secure-installation
+```
+
+### Create the database and read-only user
+
+```bash
+mariadb -u root -p
+```
+
+```sql
+CREATE DATABASE sdtDB;
+CREATE USER 'sdtreaduser'@'localhost' IDENTIFIED BY 'REPLACE_WITH_STRONG_PASSWORD';
+GRANT SELECT ON sdtDB.* TO 'sdtreaduser'@'localhost';
+FLUSH PRIVILEGES;
+QUIT;
+```
+
+---
+
+## Step 5: Populate the database
+
+### Configure the backend environment
+
+```bash
+cp backend/.env.example backend/.env
+```
+
+Edit `backend/.env` and set your database credentials:
+
+```
+DB_HOST=localhost
+DB_USER=sdtreaduser
+DB_PASSWORD=REPLACE_WITH_STRONG_PASSWORD
+DB_NAME=sdtDB
+PORT=5000
+ALLOWED_ORIGINS=http://YOUR_SERVER_IP_OR_DOMAIN
+```
+
+### Run the database build script
+
+From the repo root:
+
+```bash
+npm install
+node bin/database_build.js
+```
+
+When prompted, enter a privileged MariaDB account (e.g. root) to create the tables.
+
+### Load package data
+
+Use `bin/package_build.py` to import distro data from the `distro_data/` submodule:
+
+```bash
+python3 bin/package_build.py RHEL_9_Package_List.json
+python3 bin/package_build.py Ubuntu_2404_Package_List.json
+# Repeat for each distro you want to include
+```
+
+After adding data files, regenerate the distro config:
+
+```bash
+python3 bin/config_build.py
+```
+
+---
+
+## Step 6: Build the React frontend
+
+On your **development machine** (or the server if Node 22 is available):
+
+```bash
+cd react-frontend
+npm install
+cp .env.example .env
+```
+
+Edit `react-frontend/.env`:
+
+```
+VITE_REACT_APP_API_URL=/sdt
+```
+
+Build the production bundle:
+
+```bash
+npm run build
+```
+
+This generates compiled static files in `react-frontend/dist/`.
+
+---
+
+## Step 7: Configure Apache2
+
+### Enable required Apache modules
+
+```bash
+sudo a2enmod proxy proxy_http rewrite headers
+sudo systemctl restart apache2
+```
+
+### Create the virtual host configuration
+
+```bash
+sudo nano /etc/apache2/sites-available/software-discovery-tool.conf
+```
+
+Paste the following (replace `YOUR_DOMAIN_OR_IP`):
+
+```apache
+<VirtualHost *:80>
+    ServerName YOUR_DOMAIN_OR_IP
+
+    # Serve React static files
+    DocumentRoot /opt/software-discovery-tool/react-frontend/dist
+
+    <Directory /opt/software-discovery-tool/react-frontend/dist>
+        Options -Indexes
+        AllowOverride All
+        Require all granted
+
+        # Support React Router — send all non-file requests to index.html
+        RewriteEngine On
+        RewriteBase /
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteCond %{REQUEST_FILENAME} !-d
+        RewriteRule ^ index.html [L]
+    </Directory>
+
+    # Proxy /sdt/* to the Node.js backend
+    ProxyPass /sdt http://localhost:5000/sdt
+    ProxyPassReverse /sdt http://localhost:5000/sdt
+
+    ErrorLog ${APACHE_LOG_DIR}/sdt-error.log
+    CustomLog ${APACHE_LOG_DIR}/sdt-access.log combined
+</VirtualHost>
+```
+
+### Deploy the built files
+
+```bash
+sudo mkdir -p /opt/software-discovery-tool/react-frontend
+sudo cp -r react-frontend/dist /opt/software-discovery-tool/react-frontend/dist
+sudo chown -R www-data:www-data /opt/software-discovery-tool/react-frontend/dist
+```
+
+### Enable the site
+
+```bash
+sudo a2ensite software-discovery-tool.conf
+sudo a2dissite 000-default.conf
+sudo systemctl reload apache2
+```
+
+---
+
+## Step 8: Run the backend as a systemd service
+
+### Install backend dependencies
+
+```bash
+cd /path/to/software-discovery-tool/backend
+npm install --omit=dev
+```
+
+### Create the systemd service
+
+```bash
+sudo nano /etc/systemd/system/sdt-backend.service
+```
+
+```ini
+[Unit]
+Description=Software Discovery Tool Node.js Backend
+After=network.target mariadb.service
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/opt/software-discovery-tool/backend
+ExecStart=/usr/bin/node index.js
+Restart=on-failure
+RestartSec=5
+EnvironmentFile=/opt/software-discovery-tool/backend/.env
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Copy backend to /opt and start the service
+
+```bash
+sudo cp -r backend /opt/software-discovery-tool/backend
+sudo cp backend/.env /opt/software-discovery-tool/backend/.env
+sudo chown -R www-data:www-data /opt/software-discovery-tool/backend
+
+sudo systemctl daemon-reload
+sudo systemctl enable sdt-backend
+sudo systemctl start sdt-backend
+```
+
+Verify the backend is running:
+
+```bash
+sudo systemctl status sdt-backend
+curl http://localhost:5000/sdt/getSupportedDistros
+```
+
+---
+
+## Step 9: Verify the deployment
+
+Visit `http://YOUR_DOMAIN_OR_IP` in a browser. You should see the Software Discovery Tool frontend and be able to search for packages.
+
+If the frontend loads but searches fail, check:
+
+```bash
+sudo tail -f /var/log/apache2/sdt-error.log
+sudo journalctl -u sdt-backend -f
+```
+
+---
+
+## Updating the deployment
+
+### Update backend
+
+```bash
+cd /path/to/software-discovery-tool
+git pull
+git submodule update --recursive --remote
+cd backend && npm install --omit=dev
+sudo cp -r backend /opt/software-discovery-tool/
+sudo systemctl restart sdt-backend
+```
+
+### Update frontend
+
+```bash
+cd react-frontend
+npm install
+npm run build
+sudo cp -r dist /opt/software-discovery-tool/react-frontend/dist
+sudo chown -R www-data:www-data /opt/software-discovery-tool/react-frontend/dist
+sudo systemctl reload apache2
+```

--- a/docs/Production_Installation.md
+++ b/docs/Production_Installation.md
@@ -100,16 +100,18 @@ ALLOWED_ORIGINS=http://YOUR_SERVER_IP_OR_DOMAIN
 
 ### Load package data (optional)
 
-The `distro_data/` submodule pulled in Step 3 already includes data for all supported distributions. If you wish to import additional distro data from [PDS](https://github.com/linux-on-ibm-z/PDS/tree/master/distro_data), use `bin/package_build.py`:
+The `distro_data/` submodule pulled in Step 3 already includes data for all supported distributions.
+
+Use `bin/package_build.py` to import any [distro data from PDS](https://github.com/linux-on-ibm-z/PDS/tree/master/distro_data) you wish to include:
 
 ```bash
 python3 bin/package_build.py RHEL_9_Package_List.json
 # Repeat for each additional source you want to include
 ```
 
-The `bin/package_build.py --help` option shows all available options and sources.
+The `bin/package_build.py` can also be used to update sources you pulled in via the `distro_data` submodule if you want newer versions than included in that repository, see `--help` in the tool for more.
 
-After adding new source files, edit `config/distros.json` to include them.
+Edit `config/distros.json` to add the new source files you just pulled in.
 
 ### Run the database build script
 

--- a/docs/Production_Installation.md
+++ b/docs/Production_Installation.md
@@ -8,6 +8,8 @@ The production deployment has two components:
 - **Node.js backend** — runs as a systemd service on port 5000
 - **React frontend** — compiled to static files and served by Apache2
 
+> **Note on building the frontend:** Step 6 (building the React frontend) can be done either directly on your production server (since Node.js 22 is installed in Step 1) or on a local development machine. If you build locally, use `scp` to copy the resulting `react-frontend/dist/` directory to your server before proceeding to Step 7.
+
 ## Prerequisites
 
 - Ubuntu 24.04 server with sudo access
@@ -96,6 +98,19 @@ PORT=5000
 ALLOWED_ORIGINS=http://YOUR_SERVER_IP_OR_DOMAIN
 ```
 
+### Load package data (optional)
+
+The `distro_data/` submodule pulled in Step 3 already includes data for all supported distributions. If you wish to import additional distro data from [PDS](https://github.com/linux-on-ibm-z/PDS/tree/master/distro_data), use `bin/package_build.py`:
+
+```bash
+python3 bin/package_build.py RHEL_9_Package_List.json
+# Repeat for each additional source you want to include
+```
+
+The `bin/package_build.py --help` option shows all available options and sources.
+
+After adding new source files, edit `config/distros.json` to include them.
+
 ### Run the database build script
 
 From the repo root:
@@ -107,27 +122,9 @@ node bin/database_build.js
 
 When prompted, enter a privileged MariaDB account (e.g. root) to create the tables.
 
-### Load package data
-
-Use `bin/package_build.py` to import distro data from the `distro_data/` submodule:
-
-```bash
-python3 bin/package_build.py RHEL_9_Package_List.json
-python3 bin/package_build.py Ubuntu_2404_Package_List.json
-# Repeat for each distro you want to include
-```
-
-After adding data files, regenerate the distro config:
-
-```bash
-python3 bin/config_build.py
-```
-
 ---
 
 ## Step 6: Build the React frontend
-
-On your **development machine** (or the server if Node 22 is available):
 
 ```bash
 cd react-frontend
@@ -148,6 +145,12 @@ npm run build
 ```
 
 This generates compiled static files in `react-frontend/dist/`.
+
+If you built on a local machine, copy the `dist/` directory to your server:
+
+```bash
+scp -r react-frontend/dist/ youruser@YOUR_SERVER_IP:/path/to/software-discovery-tool/react-frontend/
+```
 
 ---
 
@@ -173,9 +176,9 @@ Paste the following (replace `YOUR_DOMAIN_OR_IP`):
     ServerName YOUR_DOMAIN_OR_IP
 
     # Serve React static files
-    DocumentRoot /opt/software-discovery-tool/react-frontend/dist
+    DocumentRoot /srv/www/software-discovery-tool/react-frontend/dist
 
-    <Directory /opt/software-discovery-tool/react-frontend/dist>
+    <Directory /srv/www/software-discovery-tool/react-frontend/dist>
         Options -Indexes
         AllowOverride All
         Require all granted
@@ -200,9 +203,8 @@ Paste the following (replace `YOUR_DOMAIN_OR_IP`):
 ### Deploy the built files
 
 ```bash
-sudo mkdir -p /opt/software-discovery-tool/react-frontend
-sudo cp -r react-frontend/dist /opt/software-discovery-tool/react-frontend/dist
-sudo chown -R www-data:www-data /opt/software-discovery-tool/react-frontend/dist
+sudo mkdir -p /srv/www/software-discovery-tool/react-frontend
+sudo cp -r react-frontend/dist /srv/www/software-discovery-tool/react-frontend/.
 ```
 
 ### Enable the site
@@ -217,11 +219,26 @@ sudo systemctl reload apache2
 
 ## Step 8: Run the backend as a systemd service
 
+### Create a dedicated system user
+
+```bash
+sudo adduser --system --no-create-home sdt
+```
+
+### Copy backend and config to /opt
+
+```bash
+sudo mkdir -p /opt/software-discovery-tool
+sudo cp -r backend /opt/software-discovery-tool/
+sudo cp -r config /opt/software-discovery-tool/
+sudo chown -R sdt /opt/software-discovery-tool/
+```
+
 ### Install backend dependencies
 
 ```bash
-cd /path/to/software-discovery-tool/backend
-npm install --omit=dev
+cd /opt/software-discovery-tool/backend
+sudo -u sdt npm install --omit=dev
 ```
 
 ### Create the systemd service
@@ -237,7 +254,7 @@ After=network.target mariadb.service
 
 [Service]
 Type=simple
-User=www-data
+User=sdt
 WorkingDirectory=/opt/software-discovery-tool/backend
 ExecStart=/usr/bin/node index.js
 Restart=on-failure
@@ -248,13 +265,9 @@ EnvironmentFile=/opt/software-discovery-tool/backend/.env
 WantedBy=multi-user.target
 ```
 
-### Copy backend to /opt and start the service
+### Start the service
 
 ```bash
-sudo cp -r backend /opt/software-discovery-tool/backend
-sudo cp backend/.env /opt/software-discovery-tool/backend/.env
-sudo chown -R www-data:www-data /opt/software-discovery-tool/backend
-
 sudo systemctl daemon-reload
 sudo systemctl enable sdt-backend
 sudo systemctl start sdt-backend
@@ -290,8 +303,10 @@ sudo journalctl -u sdt-backend -f
 cd /path/to/software-discovery-tool
 git pull
 git submodule update --recursive --remote
-cd backend && npm install --omit=dev
 sudo cp -r backend /opt/software-discovery-tool/
+sudo cp -r config /opt/software-discovery-tool/
+sudo chown -R sdt /opt/software-discovery-tool/
+cd /opt/software-discovery-tool/backend && sudo -u sdt npm install --omit=dev
 sudo systemctl restart sdt-backend
 ```
 
@@ -301,7 +316,6 @@ sudo systemctl restart sdt-backend
 cd react-frontend
 npm install
 npm run build
-sudo cp -r dist /opt/software-discovery-tool/react-frontend/dist
-sudo chown -R www-data:www-data /opt/software-discovery-tool/react-frontend/dist
+sudo cp -r dist /srv/www/software-discovery-tool/react-frontend/.
 sudo systemctl reload apache2
 ```

--- a/react-frontend/package-lock.json
+++ b/react-frontend/package-lock.json
@@ -31,6 +31,7 @@
       "devDependencies": {
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "autoprefixer": "^10.5.0",
+        "jsdom": "^29.1.1",
         "tailwindcss": "^3.4.4",
         "vitest": "^4.1.9"
       }
@@ -52,6 +53,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
@@ -72,6 +124,7 @@
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -143,6 +196,7 @@
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.29.7",
         "@babel/helper-validator-option": "^7.29.7",
@@ -218,6 +272,7 @@
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.29.7",
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -309,6 +364,7 @@
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -319,6 +375,7 @@
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/template": "^7.29.7",
         "@babel/types": "^7.29.7"
@@ -434,12 +491,189 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -539,7 +773,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.13.0.tgz",
       "integrity": "sha512-WkL+bw1REC2VNV1goQyfxjx1GYJkcc23CRQkXX+vZNLINyfI7o+uUn/rTGPt/xJ3bJHd5GcljgnxHf4wRw5VWQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.12.0",
@@ -653,6 +886,24 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==",
       "license": "MIT"
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -798,6 +1049,7 @@
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -809,16 +1061,6 @@
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -878,7 +1120,6 @@
       "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.16.4.tgz",
       "integrity": "sha512-dBnh3/zRYgEVIS3OE4oTbujse3gifA0qLMmuUk13ywsDCbngJsdgwW5LuYeiT5pfA8PGPGSqM7mxNytYXgiMCw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.9",
         "@mui/core-downloads-tracker": "^5.16.4",
@@ -1687,7 +1928,6 @@
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1879,19 +2119,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2056,6 +2283,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -2099,7 +2336,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2113,12 +2349,6 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
-    },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "optional": true
     },
     "node_modules/call-bind": {
       "version": "1.0.7",
@@ -2381,6 +2611,20 @@
         "postcss-value-parser": "^4.0.2"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -2403,6 +2647,20 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
@@ -2418,6 +2676,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-equal": {
       "version": "2.2.3",
@@ -2571,6 +2836,19 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/enquire.js/-/enquire.js-2.1.6.tgz",
       "integrity": "sha512-/KujNpO+PT63F7Hlpu4h3pE3TokKRHN26JYmQpPyjkRD/N57R7bPDNojMXdi7uveAKjYB7yQnartCxZnFWr0Xw=="
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -2830,6 +3108,7 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2978,6 +3257,19 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -3197,6 +3489,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.1.4",
@@ -3493,6 +3792,57 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -3524,6 +3874,7 @@
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -3822,6 +4173,7 @@
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -3852,6 +4204,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4058,6 +4417,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4175,7 +4547,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -4344,6 +4715,16 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -4368,7 +4749,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4391,7 +4771,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4545,6 +4924,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
@@ -4630,6 +5019,19 @@
       ],
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4798,25 +5200,6 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "optional": true,
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5113,6 +5496,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.4.tgz",
@@ -5149,30 +5539,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/terser": {
-      "version": "5.31.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.1.tgz",
-      "integrity": "sha512-37upzU1+viGvuFtBo9NPufCb9dwM0+l9hMxYyWfBA+fbwrPqNJAhbZ6W47bBFnZHKHTUBnMvi87434qq+qnxOg==",
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "optional": true
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -5250,7 +5616,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5268,6 +5633,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+      "integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.9"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.9",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+      "integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -5277,6 +5662,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -5290,6 +5701,16 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
       "optional": true
+    },
+    "node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/undici-types": {
       "version": "7.24.6",
@@ -5344,7 +5765,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -5532,10 +5952,58 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-vitals": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
       "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -5637,12 +6105,30 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yaml": {
       "version": "2.9.0",

--- a/react-frontend/package.json
+++ b/react-frontend/package.json
@@ -23,14 +23,12 @@
     "vite": "^8.0.14",
     "web-vitals": "^2.1.4"
   },
-  
   "scripts": {
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest"
   },
-
   "browserslist": {
     "production": [
       ">0.2%",
@@ -46,6 +44,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "autoprefixer": "^10.5.0",
+    "jsdom": "^29.1.1",
     "tailwindcss": "^3.4.4",
     "vitest": "^4.1.9"
   }

--- a/react-frontend/src/test/SearchResults.test.jsx
+++ b/react-frontend/src/test/SearchResults.test.jsx
@@ -1,0 +1,74 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SearchResults from '../components/SearchResults';
+
+const mockResults = [
+  {
+    packageName: 'curl',
+    version: '7.88.1',
+    description: 'Command line tool for transferring data',
+    ostag: 'Ubuntu 22.04',
+    repo: null,
+  },
+  {
+    packageName: 'wget',
+    version: '1.21.3',
+    description: 'Network downloader',
+    ostag: 'RHEL 9',
+    repo: 'https://example.com/repo',
+  },
+];
+
+const defaultProps = {
+  results: mockResults,
+  showDesc: true,
+  itemsPerPage: 10,
+  searchPerformed: true,
+  totalResultsCount: 2,
+  selectedParentDistributions: [],
+  osList: {},
+  currentPage: 0,
+  totalPages: 1,
+  onPageChange: vi.fn(),
+};
+
+describe('SearchResults', () => {
+  it('renders package names', () => {
+    render(<SearchResults {...defaultProps} />);
+    expect(screen.getByText('curl')).toBeInTheDocument();
+    expect(screen.getByText('wget')).toBeInTheDocument();
+  });
+
+  it('renders distro tag when ostag is present', () => {
+    render(<SearchResults {...defaultProps} />);
+    expect(screen.getByText('Ubuntu 22.04')).toBeInTheDocument();
+    expect(screen.getByText('RHEL 9')).toBeInTheDocument();
+  });
+
+  it('does not render any unexpected links', () => {
+    render(<SearchResults {...defaultProps} />);
+    expect(screen.queryByRole('link', { name: /validated/i })).not.toBeInTheDocument();
+  });
+
+  it('renders descriptions when showDesc is true', () => {
+    render(<SearchResults {...defaultProps} />);
+    expect(screen.getByText('Command line tool for transferring data')).toBeInTheDocument();
+  });
+
+  it('filters results by package name using refine input', () => {
+    render(<SearchResults {...defaultProps} />);
+    const refineInput = screen.getByPlaceholderText('Search within page...');
+    fireEvent.change(refineInput, { target: { value: 'curl' } });
+    expect(screen.getByText('curl')).toBeInTheDocument();
+    expect(screen.queryByText('wget')).not.toBeInTheDocument();
+  });
+
+  it('shows no results message when search performed but results empty', () => {
+    render(<SearchResults {...defaultProps} results={[]} totalResultsCount={0} />);
+    expect(screen.queryByText('curl')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when search has not been performed', () => {
+    render(<SearchResults {...defaultProps} searchPerformed={false} results={[]} />);
+    expect(screen.queryByText('curl')).not.toBeInTheDocument();
+  });
+});

--- a/react-frontend/src/test/normalizeApiBaseUrl.test.js
+++ b/react-frontend/src/test/normalizeApiBaseUrl.test.js
@@ -1,0 +1,43 @@
+// Tests for the URL normalization utility used in SearchBar
+
+const normalizeApiBaseUrl = (rawUrl) => {
+  const trimmedUrl = (rawUrl || '').trim();
+  if (!trimmedUrl || trimmedUrl === 'undefined' || trimmedUrl === 'null') {
+    return 'http://localhost:5000';
+  }
+  return trimmedUrl.replace(/\/+$/, '');
+};
+
+describe('normalizeApiBaseUrl', () => {
+  it('returns default URL for empty string', () => {
+    expect(normalizeApiBaseUrl('')).toBe('http://localhost:5000');
+  });
+
+  it('returns default URL for undefined', () => {
+    expect(normalizeApiBaseUrl(undefined)).toBe('http://localhost:5000');
+  });
+
+  it('returns default URL for null', () => {
+    expect(normalizeApiBaseUrl(null)).toBe('http://localhost:5000');
+  });
+
+  it('returns default URL for string "undefined"', () => {
+    expect(normalizeApiBaseUrl('undefined')).toBe('http://localhost:5000');
+  });
+
+  it('strips trailing slash', () => {
+    expect(normalizeApiBaseUrl('http://localhost:5000/')).toBe('http://localhost:5000');
+  });
+
+  it('strips multiple trailing slashes', () => {
+    expect(normalizeApiBaseUrl('http://localhost:5000///')).toBe('http://localhost:5000');
+  });
+
+  it('preserves valid URL unchanged', () => {
+    expect(normalizeApiBaseUrl('http://prod.example.com/sdt')).toBe('http://prod.example.com/sdt');
+  });
+
+  it('trims whitespace', () => {
+    expect(normalizeApiBaseUrl('  http://localhost:5000  ')).toBe('http://localhost:5000');
+  });
+});

--- a/react-frontend/src/test/setup.js
+++ b/react-frontend/src/test/setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/react-frontend/vite.config.js
+++ b/react-frontend/vite.config.js
@@ -9,5 +9,10 @@ export default defineConfig({
     proxy: {
       '/sdt': 'http://localhost:5000'
     }
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.js'],
   }
 })


### PR DESCRIPTION
## Summary
- Adds `docs/Production_Installation.md` — a step-by-step guide for deploying the Software Discovery Tool on Ubuntu 24.04 using Apache2 as a reverse proxy
- Covers Node.js 22 (via NodeSource), MariaDB setup with read-only user, database build script, Vite React frontend build, Apache virtual host config, and systemd service for the Node.js backend
- Includes an "Updating the deployment" section for keeping the backend and frontend in sync
