### PR TITLE
ci: upgrade actions/checkout and actions/setup-node to v5

### DIFF
--- a/.github/workflows/frontend-security-audit.yml
+++ b/.github/workflows/frontend-security-audit.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'


### PR DESCRIPTION
Upgrade `actions/checkout` and `actions/setup-node` from v4 to v5.

Both v4 actions use Node.js 20 as their internal runner runtime, which GitHub has deprecated. v5 uses Node.js 24, eliminating the deprecation warning in CI.

No code changes — workflow only.